### PR TITLE
schedules#editページにOKとNGボタンを実装

### DIFF
--- a/app/assets/stylesheets/make_plans.scss
+++ b/app/assets/stylesheets/make_plans.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the make_plans controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/make_plans_controller.rb
+++ b/app/controllers/make_plans_controller.rb
@@ -1,0 +1,18 @@
+class MakePlansController < ApplicationController
+  require 'net/http'
+  require 'uri'
+
+  def create
+    idToken = params[:idToken]
+    channelId = '1655665365'
+    res = Net::HTTP.post_form(URI.parse('https://api.line.me/oauth2/v2.1/verify'),
+                          {'id_token'=>idToken, 'client_id'=>channelId})
+    render :json => res.body
+    partner_id = params[:dataId]
+    inviter_id = Schedule.find_by(token: params[:scheduleToken]).inviter_id
+    schedule = Schedule.find_by(token: params[:scheduleToken])
+    plan = MakePlan.new(inviter_id: inviter_id, partner_id: partner_id,schedule_id: schedule.id)
+    # 誤って二重に登録するのを防止
+    plan.save! if MakePlan.find_by(schedule_id: schedule.id) == nil
+  end
+end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -48,8 +48,8 @@ class SchedulesController < ApplicationController
 
   def update
     @schedule = Schedule.find(params[:id])
-    # 開始時刻より後でもOKできるように、バリデーションスキップ
     @schedule.assign_attributes(answer: 1)
+    # 開始時刻より後でもOKできるように、バリデーションスキップ
     @schedule.save!(validate: false)
     render json: @schedule
     message = {

--- a/app/helpers/make_plans_helper.rb
+++ b/app/helpers/make_plans_helper.rb
@@ -1,0 +1,2 @@
+module MakePlansHelper
+end

--- a/app/javascript/packs/schedules/edit.js
+++ b/app/javascript/packs/schedules/edit.js
@@ -1,0 +1,63 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+  // 他のメソッドを実行できるようになるための作業
+  liff.init({
+    liffId: "1655665365-robLXJ1P"
+  })
+  .then(() => {
+    if (!liff.isLoggedIn()) {
+      liff.login();
+    }
+  })
+  .then(() => {
+    const postFormElm = document.querySelector('#ok')
+    postFormElm.addEventListener('ajax:success', (e) => {
+      console.log(e.detail[0])
+      const scheduleToken = e.detail[0].token
+
+      // partnerのline_user_idを保存するための処理
+      const idToken = liff.getIDToken()
+      console.log(idToken)
+      const body =`idToken=${idToken}`
+      const request = new Request('/users', {
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+          'X-CSRF-Token': token
+        },
+        method: 'POST',
+        body: body
+      });
+
+      fetch(request)
+      .then(response => response.json())
+      .then(data => {
+        dataId = data.id
+      })
+      .then(() => {
+      // make_plansテーブルに保存するための処理
+        const data =`idToken=${idToken}&dataId=${dataId}&scheduleToken=${scheduleToken}`
+        const req = new Request('/make_plans', {
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+            'X-CSRF-Token': token
+          },
+          method: 'POST',
+          body: data
+        });
+
+        fetch(req)
+        .then(response => response.json())
+        .then(data => {
+          data_id = data.id
+        })
+      })
+      .then(() => {
+        liff.closeWindow();
+      })
+      .catch((err) => {
+        console.log(err.code, err.message);
+      });
+    })
+  })
+})

--- a/app/javascript/packs/schedules/new.js
+++ b/app/javascript/packs/schedules/new.js
@@ -1,7 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
   const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
   // 他のメソッドを実行できるようになるための作業
-  debugger
   liff.init({
     liffId: "1655665365-robLXJ1P"
   })

--- a/app/models/make_plan.rb
+++ b/app/models/make_plan.rb
@@ -1,0 +1,8 @@
+class MakePlan < ApplicationRecord
+  # invitedモデルを探しにいってしまうので、class_nameを指定してあげる
+  belongs_to :inviter, class_name: 'User'
+  belongs_to :partner, class_name: 'User'
+  belongs_to :schedule
+
+  validates :schedule_id, uniqueness: true
+end

--- a/app/views/make_plans/create.html.slim
+++ b/app/views/make_plans/create.html.slim
@@ -1,0 +1,2 @@
+h1 MakePlans#create
+p Find me in app/views/make_plans/create.html.slim

--- a/app/views/schedules/edit.html.slim
+++ b/app/views/schedules/edit.html.slim
@@ -17,7 +17,10 @@ p
   br
   = @schedule.other
   br
-  = link_to "OKする", schedule_path(@schedule.id), data: { confirm: 'パートナーにOKの通知をします。よろしいですか?' },
+  = link_to "OK!", schedule_path(@schedule.id), data: { confirm: 'パートナーにOKの通知をします。よろしいですか?' },
                                                  method: :PATCH, id: 'ok', remote: true
+  br
+  = link_to "NG...", schedule_path(@schedule.id), data: { confirm: '後から返答を変更することはできません。よろしいですか?' },
+                                                 method: :DELETE, id: 'ng'
 
 = javascript_pack_tag 'schedules/edit'

--- a/app/views/schedules/edit.html.slim
+++ b/app/views/schedules/edit.html.slim
@@ -1,2 +1,23 @@
-<h1>Schedules#edit</h1>
-<p>Find me in app/views/schedules/edit.html.erb</p>
+h1
+  |スケジュール内容
+p
+  |開始時間:
+  br
+  = l @schedule.start_planned_day_at
+p
+  |終了予定時間:
+  br
+  = l @schedule.finish_planned_day_at
+p
+  |場所:
+  br
+  = @schedule.place
+p
+  |やりたいこと:
+  br
+  = @schedule.other
+  br
+  = link_to "OKする", schedule_path(@schedule.id), data: { confirm: 'パートナーにOKの通知をします。よろしいですか?' },
+                                                 method: :PATCH, id: 'ok', remote: true
+
+= javascript_pack_tag 'schedules/edit'

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,8 @@ module DateMe
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.time_zone = "Tokyo"
+    config.i18n.default_locale = :ja
 
     # Don't generate system test files.
     config.generators.system_tests = nil

--- a/config/locales/ya.yml
+++ b/config/locales/ya.yml
@@ -1,0 +1,212 @@
+ja:
+  activerecord:
+    attributes:
+      schedule:
+        start_planned_day_at: 開始時間
+        finish_planned_day_at: 終了予定時間
+        place: 場所
+        other: やりたいこと
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y/%m/%d %H:%M"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
-  resources :users
-  resources :schedules
+  resources :users, only: [:create]
+  resources :schedules, only: [:create, :new, :update, :index]
+  resources :make_plans, only: [:create]
+  
   root 'schedules#show'
+  get '/schedules/:token' => 'schedules#edit'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 Rails.application.routes.draw do
   get 'make_plans/create'
   resources :users, only: [:create]
-  resources :schedules, only: [:create, :new, :update, :index]
+  resources :schedules, only: [:create, :new, :update, :index, :destroy]
   resources :make_plans, only: [:create]
-  
+
   root 'schedules#show'
   get '/schedules/:token' => 'schedules#edit'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'make_plans/create'
   resources :users, only: [:create]
   resources :schedules, only: [:create, :new, :update, :index]
   resources :make_plans, only: [:create]

--- a/db/migrate/20210215025639_create_make_plans.rb
+++ b/db/migrate/20210215025639_create_make_plans.rb
@@ -1,0 +1,11 @@
+class CreateMakePlans < ActiveRecord::Migration[6.1]
+  def change
+    create_table :make_plans do |t|
+      t.references :inviter, null: false, foreign_key: { to_table: :users }, index: true
+      t.references :partner, null: false, foreign_key: { to_table: :users }, index: true
+      t.references :schedule, null: false, foreign_key: true, index: {unique: true}
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_12_135435) do
+ActiveRecord::Schema.define(version: 2021_02_15_025639) do
+
+  create_table "make_plans", charset: "utf8mb4", force: :cascade do |t|
+    t.bigint "inviter_id", null: false
+    t.bigint "partner_id", null: false
+    t.bigint "schedule_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["inviter_id"], name: "index_make_plans_on_inviter_id"
+    t.index ["partner_id"], name: "index_make_plans_on_partner_id"
+    t.index ["schedule_id"], name: "index_make_plans_on_schedule_id", unique: true
+  end
 
   create_table "schedules", charset: "utf8mb4", force: :cascade do |t|
     t.datetime "start_planned_day_at", null: false
@@ -31,5 +42,8 @@ ActiveRecord::Schema.define(version: 2021_02_12_135435) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "make_plans", "schedules"
+  add_foreign_key "make_plans", "users", column: "inviter_id"
+  add_foreign_key "make_plans", "users", column: "partner_id"
   add_foreign_key "schedules", "users", column: "inviter_id"
 end

--- a/spec/factories/make_plans.rb
+++ b/spec/factories/make_plans.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :make_plan do
+    inviter { nil }
+    partner { nil }
+    schedule { nil }
+  end
+end

--- a/spec/helpers/make_plans_helper_spec.rb
+++ b/spec/helpers/make_plans_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the MakePlansHelper. For example:
+#
+# describe MakePlansHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe MakePlansHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/make_plan_spec.rb
+++ b/spec/models/make_plan_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe MakePlan, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/make_plans_request_spec.rb
+++ b/spec/requests/make_plans_request_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe "MakePlans", type: :request do
+
+  describe "GET /create" do
+    it "returns http success" do
+      get "/make_plans/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/make_plans/create.html.slim_spec.rb
+++ b/spec/views/make_plans/create.html.slim_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "make_plans/create.html.slim", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要

 schedules#editページにOKとNGボタンを作成しOKされたらanswerカラムをokに変更、NGの時はschedule自体が削除されるように実装しました。  
schedulesテーブルとusersテーブルの中間テーブル(make_plansテーブルを作成)しました。  
make_plansコントローラを作成し、partnerが返事をするとmake_plansテーブルに保存されるようにしました。  
<br>
■その他■
タイムゾーンを日本時間に変更しました。  
i18nで日本語化対応しました。 

## 確認方法

カラムを追加したので `bundle exec rails db:migrate` を実行してください