### PR TITLE
エラーハンドリング実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,21 @@
 class ApplicationController < ActionController::Base
   # CSRF保護を無効にする
   protect_from_forgery with: :null_session
+
+  rescue_from StandardError, with: :render_500
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+  rescue_from ActionController::RoutingError, with: :render_404
+
+  private
+
+  def render_404
+    render file: Rails.root.join('public', '404.html'), layout: false, status: :not_found
+  end
+
+  def render_500(error = nil)
+    # log/development.logに記録される
+    logger.error(error.message)
+    logger.error(error.backtrace.join('\n'))
+    render file: Rails.root.join('public', '500.html'), layout: false, status: :internal_server_error
+  end
 end

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -44,6 +44,9 @@ class SchedulesController < ApplicationController
 
   def edit
     @schedule = Schedule.find_by(token: params[:token])
+    if @schedule == nil || @schedule.answer == 'ok'
+      raise ActiveRecord::RecordNotFound
+    end
   end
 
   def update

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -76,4 +76,5 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+  #config.consider_all_request_local = false
 end

--- a/lib/tasks/push.rake
+++ b/lib/tasks/push.rake
@@ -35,7 +35,7 @@ namespace :push do
   end
 
   task push_remind: :environment do
-    schedules = Schedule.where('start_planned_day_at <= ? and finish_planned_day_at >= ? and answer = ?', Time.now.since(1.hours), Time.now.since(1.hours).since(1.minutes), 1)
+    schedules = Schedule.where('start_planned_day_at <= ? and start_planned_day_at >= ? and answer = ?', Time.now.since(1.hours), Time.now.since(1.hours).since(1.minutes), 1)
     schedules.each do |schedule|
       message = {
         type: 'text',


### PR DESCRIPTION
## 概要

スケジュールを確認するためのURLを開いて回答した後、同じページにアクセスするとエラーページにアクセスするよう、エラーハンドリングを実装しました。
・rescue_fromを用いて実装しています。
・NGを押してスケジュールがdestroyされた、OKを押してanswerカラムがokに変更された、どちらの場合も再度URLを開こうとすると404エラーページにアクセスします。