### PR TITLE
bundle exec cap production deployコマンドが実行できるようにしたい

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -12,6 +12,7 @@ require "capistrano/nginx"
 
 install_plugin Capistrano::SCM::Git
 install_plugin Capistrano::Puma
+install_plugin Capistrano::Puma::Daemon
 install_plugin Capistrano::Puma::Nginx
 
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,7 @@ GEM
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     libv8 (8.4.255.0-x86_64-darwin-19)
+    libv8 (8.4.255.0-x86_64-linux)
     line-bot-api (1.18.0)
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -152,6 +153,8 @@ GEM
     net-ssh (6.1.0)
     nio4r (2.5.5)
     nokogiri (1.11.1-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.11.1-x86_64-linux)
       racc (~> 1.4)
     parallel (1.20.1)
     parser (3.0.0.0)
@@ -289,6 +292,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   bcrypt_pbkdf

--- a/app/views/schedules/edit.html.slim
+++ b/app/views/schedules/edit.html.slim
@@ -16,7 +16,6 @@ div.border.rounded-t.border-gray-500
     |やりたいこと:
     br
     = @schedule.other
-
 br
 br
 div.edit-container.wf-kokoro.font-bold

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -16,6 +16,7 @@ set :puma_pid, "/var/www/Date_me/shared/tmp/pids/puma.pid"
 set :puma_access_log, "/var/www/Date_me/shared/log/puma.error.log"
 set :puma_error_log, "/var/www/Date_me/shared/log/puma.access.log"
 set :puma_preload_app, true
+set :branch, ENV['BRANCH'] || "main"
 
 namespace :puma do
   desc 'Create Directories for Puma Pids and Socket'


### PR DESCRIPTION
### 現状発生している問題・エラーメッセージ

https://runteq.jp/skill_categories/aws
AWSへデプロイするため、RUNTEQのAWSカリキュラムに沿って進めていきましたが、
`bundle exec cap production deploy`コマンドを実行すると以下のエラーが出ます。
```
(Backtrace restricted to imported tasks)
cap aborted!
Don't know how to build task 'start' (See the list of available tasks with `cap --tasks`)

Tasks: TOP => production
(See full trace by running task with --trace)
```

### 該当のソースコード

config/deploy.rb
```
# config valid for current version and patch releases of Capistrano
lock "~> 3.15.0"

set :application, "Date_me"
set :repo_url, "git@github.com:terakura-aina/Date_me.git" # 自身のリモートリポジトリURL
set :user, 'aina'
set :deploy_to, "/var/www/Date_me"
set :linked_files, %w[config/master.key config/database.yml]
set :linked_dirs, %w[log tmp/pids tmp/cache tmp/sockets public/system vendor/bundle]
set :rbenv_ruby, File.read('.ruby-version').strip
set :puma_threds, [4, 16]
set :puma_workers, 0
set :puma_bind, "unix:///var/www/Date_me/shared/tmp/sockets/puma.sock"
set :puma_state, "/var/www/Date_me/shared/tmp/pids/puma.state"
set :puma_pid, "/var/www/Date_me/shared/tmp/pids/puma.pid"
set :puma_access_log, "/var/www/Date_me/shared/log/puma.error.log"
set :puma_error_log, "/var/www/Date_me/shared/log/puma.access.log"
set :puma_preload_app, true

namespace :puma do
  desc 'Create Directories for Puma Pids and Socket'
  task :make_dirs do
    on roles(:app) do
      execute "mkdir /var/www/Date_me/shared/tmp/sockets -p"
      execute "mkdir /var/www/Date_me/shared/tmp/pids -p"
    end
  end

  before :start, :make_dirs
end

namespace :deploy do
  desc 'upload important files'
  task :upload do
    on roles(:app) do
      sudo :mkdir, '-p', "/var/www/Date_me/shared/config"
      sudo %[chown -R #{fetch(:user)}.#{fetch(:user)} /var/www/#{fetch(:application)}]
      sudo :mkdir, '-p', '/etc/nginx/sites-enabled'
      sudo :mkdir, '-p', '/etc/nginx/sites-available'

      upload!('config/database.yml', "/var/www/Date_me/shared/config/database.yml")
      upload!('config/master.key', "/var/www/Date_me/shared/config/master.key")
    end
  end

  desc 'Create database'
  task :db_create do
    on roles(:db) do
      with rails_env: fetch(:rails_env) do
        within release_path do
          execute :bundle, :exec, :rake, 'db:create'
        end
      end
    end
  end

  before :starting, :upload
  before 'check:linked_files', 'puma:nginx_config'
end

after 'deploy:published', 'nginx:restart'
before 'deploy:migrate', 'deploy:db_create'

```
Capfile
```
require "capistrano/setup"
require "capistrano/deploy"
require "capistrano/rails"
require "capistrano/rbenv"
require "capistrano/bundler"
require "capistrano/rails/migrations"
require "capistrano/rails/assets"
require 'capistrano/yarn'
require "capistrano/scm/git"
require "capistrano/puma"
require "capistrano/nginx"

install_plugin Capistrano::SCM::Git
install_plugin Capistrano::Puma
install_plugin Capistrano::Puma::Nginx

Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }
```

Gemfile
```
gem 'capistrano'
  gem 'ed25519'
  gem 'bcrypt_pbkdf'
  gem 'capistrano-rbenv'
  gem 'capistrano-bundler'
  gem 'capistrano-rails'
  gem 'capistrano3-puma'
  gem 'capistrano-nginx'
  gem 'capistrano-yarn'
```

### 試したこと

まずは`Don't know how to build task 'start'`や`(See the list of available tasks with "cap --tasks") `などのエラー文を調べてみたところ、

https://stackoverflow.com/questions/43014993/dont-know-how-to-build-task-start-when-run-cap-production-deploy-for-capist
https://qiita.com/hayashiki/items/fca4f33467e2a6c1f944

同じ解決策が書かれているサイトを複数確認しました。

解決策としては、Capfileに`install_plugin Capistrano::Puma`と記述すること(新しいバージョンになり、この記述が必要になったといったような理由でした)

ただ、自分のファイルを確認したところ、既に`install_plugin Capistrano::Puma`この記述はされていました。

これ以外の解決策を書いている記事は見つけることができませんでした。

次に、エラー箇所だと予測しているconfig/deploy.rbの`before :start, :make_dirs`、この部分が本当にエラーと関係があるのかを調べるため、一度この記述を削除し、`bundle exec cap production deploy --trace --dry-run`コマンドで実行できるかを試してみました。(`dey-run`は実際に実行できるかを試すことができるコマンドと認識しています)
https://qiita.com/nasum/items/d72112d0928a4073f71c

すると先ほどまで出ていたエラーは消え、以下のようなログに変わりました。(おそらく成功しているということでしょうか？）
```
user@USERnoMacBook-Air Date_me % bundle exec cap production deploy --trace --dry-run                                                                                                       [main]export
** Invoke production (first_time)
** Execute production
** Invoke load:defaults (first_time)
** Execute load:defaults
** Invoke bundler:map_bins (first_time)
** Execute bundler:map_bins
** Invoke deploy:set_rails_env (first_time)
** Execute deploy:set_rails_env
** Invoke deploy:set_linked_dirs (first_time)
** Execute deploy:set_linked_dirs
** Invoke deploy:set_rails_env 
** Invoke rbenv:validate (first_time)
** Execute rbenv:validate
** Invoke rbenv:map_bins (first_time)
** Execute rbenv:map_bins
** Invoke deploy (first_time)
** Execute deploy
** Invoke deploy:starting (first_time)
** Invoke deploy:upload (first_time)
** Execute deploy:upload
00:00 deploy:upload
      01 sudo mkdir -p /var/www/Date_me/shared/config
      02 sudo chown -R aina.aina /var/www/Date_me
      03 sudo mkdir -p /etc/nginx/sites-enabled
      04 sudo mkdir -p /etc/nginx/sites-available
      05 config/database.yml /var/www/Date_me/shared/config/database.yml
      06 config/master.key /var/www/Date_me/shared/config/master.key
** Execute deploy:starting
** Invoke deploy:check (first_time)
** Invoke git:check (first_time)
** Invoke git:wrapper (first_time)
** Execute git:wrapper
00:00 git:wrapper
      01 mkdir -p /tmp
      02 #<StringIO:0x00007f9ed5aefa80> /tmp/git-ssh-b5bf60e958a37b6fe5cc.sh
      03 chmod 700 /tmp/git-ssh-b5bf60e958a37b6fe5cc.sh
** Execute git:check
00:00 git:check
      01 git ls-remote git@github.com:terakura-aina/Date_me.git HEAD
** Execute deploy:check
** Invoke deploy:check:directories (first_time)
** Execute deploy:check:directories
00:00 deploy:check:directories
      01 mkdir -p /var/www/Date_me/shared /var/www/Date_me/releases
** Invoke deploy:check:linked_dirs (first_time)
** Execute deploy:check:linked_dirs
00:00 deploy:check:linked_dirs
      01 mkdir -p /var/www/Date_me/shared/log /var/www/Date_me/shared/tmp/pids /var/www/Date_me/shared/tmp/cache /var/www/Date_me/shared/tmp/sockets /var/www/Date_me/shared/public/system /var/www/Dat…
** Invoke deploy:check:make_linked_dirs (first_time)
** Execute deploy:check:make_linked_dirs
00:00 deploy:check:make_linked_dirs
      01 mkdir -p /var/www/Date_me/shared/config
** Invoke deploy:check:linked_files (first_time)
** Invoke puma:nginx_config (first_time)
** Execute puma:nginx_config
00:00 puma:nginx_config
      01 #<StringIO:0x00007f9ed5b34950> /tmp/nginx_Date_me_production
      02 sudo mv /tmp/nginx_Date_me_production /etc/nginx/sites-available/Date_me_production
      03 sudo ln -fs /etc/nginx/sites-available/Date_me_production /etc/nginx/sites-enabled/Date_me_production
** Execute deploy:check:linked_files
** Invoke puma:check (first_time)
** Execute puma:check
** Invoke deploy:set_previous_revision (first_time)
** Execute deploy:set_previous_revision
** Invoke deploy:started (first_time)
** Execute deploy:started
** Invoke deploy:updating (first_time)
** Invoke deploy:new_release_path (first_time)
** Execute deploy:new_release_path
** Invoke git:create_release (first_time)
** Invoke git:update (first_time)
** Invoke git:clone (first_time)
** Invoke git:wrapper 
** Execute git:clone
00:00 git:clone
      The repository mirror is at /var/www/Date_me/repo
** Execute git:update
00:00 git:update
      01 git remote set-url origin git@github.com:terakura-aina/Date_me.git
      02 git remote update --prune
** Execute git:create_release
00:00 git:create_release
      01 mkdir -p /var/www/Date_me/releases/20210225063333
      02 git archive master | /usr/bin/env tar -x -f - -C /var/www/Date_me/releases/20210225063333
** Execute deploy:updating
** Invoke deploy:set_current_revision (first_time)
** Invoke git:set_current_revision (first_time)
** Execute git:set_current_revision
** Execute deploy:set_current_revision
00:00 deploy:set_current_revision
      01 echo "" > REVISION
** Invoke deploy:symlink:shared (first_time)
** Execute deploy:symlink:shared
** Invoke deploy:symlink:linked_files (first_time)
** Execute deploy:symlink:linked_files
00:00 deploy:symlink:linked_files
      01 mkdir -p /var/www/Date_me/releases/20210225063333/config
** Invoke deploy:symlink:linked_dirs (first_time)
** Execute deploy:symlink:linked_dirs
00:00 deploy:symlink:linked_dirs
      01 mkdir -p /var/www/Date_me/releases/20210225063333 /var/www/Date_me/releases/20210225063333/tmp /var/www/Date_me/releases/20210225063333/public /var/www/Date_me/releases/20210225063333/vendor
** Invoke deploy:updated (first_time)
** Invoke bundler:install (first_time)
** Invoke bundler:config (first_time)
** Execute bundler:config
00:00 bundler:config
      01 $HOME/.rbenv/bin/rbenv exec bundle config --local deployment true
      02 $HOME/.rbenv/bin/rbenv exec bundle config --local path /var/www/Date_me/shared/bundle
      03 $HOME/.rbenv/bin/rbenv exec bundle config --local without development:test
** Execute bundler:install
00:00 bundler:install
      The Gemfile's dependencies are satisfied, skipping installation
** Invoke yarn:install (first_time)
** Execute yarn:install
00:00 yarn:install
      01 yarn install --production
** Execute deploy:updated
** Invoke deploy:compile_assets (first_time)
** Invoke deploy:set_rails_env 
** Execute deploy:compile_assets
** Invoke deploy:assets:precompile (first_time)
** Execute deploy:assets:precompile
00:00 deploy:assets:precompile
      01 $HOME/.rbenv/bin/rbenv exec bundle exec rake assets:precompile
** Invoke deploy:assets:backup_manifest (first_time)
** Execute deploy:assets:backup_manifest
00:00 deploy:assets:backup_manifest
      01 mkdir -p /var/www/Date_me/releases/20210225063333/assets_manifest_backup
      02 cp  /var/www/Date_me/releases/20210225063333/assets_manifest_backup
** Invoke deploy:cleanup_assets (first_time)
** Invoke deploy:set_rails_env 
** Execute deploy:cleanup_assets
** Invoke deploy:normalize_assets (first_time)
** Invoke deploy:set_rails_env 
** Execute deploy:normalize_assets
** Invoke deploy:migrate (first_time)
** Invoke deploy:set_rails_env 
** Invoke deploy:db_create (first_time)
** Execute deploy:db_create
00:00 deploy:db_create
      01 $HOME/.rbenv/bin/rbenv exec bundle exec rake db:create
** Execute deploy:migrate
00:00 deploy:migrate
      [deploy:migrate] Run `rake db:migrate`
** Invoke deploy:migrating (first_time)
** Invoke deploy:set_rails_env 
** Execute deploy:migrating
00:00 deploy:migrating
      01 $HOME/.rbenv/bin/rbenv exec bundle exec rake db:migrate
** Invoke deploy:publishing (first_time)
** Execute deploy:publishing
** Invoke deploy:symlink:release (first_time)
** Execute deploy:symlink:release
00:00 deploy:symlink:release
      01 ln -s /var/www/Date_me/releases/20210225063333 /var/www/Date_me/releases/current
      02 mv /var/www/Date_me/releases/current /var/www/Date_me
** Invoke deploy:published (first_time)
** Execute deploy:published
** Invoke nginx:restart (first_time)
** Execute nginx:restart
00:00 nginx:restart
      01 sudo service nginx restart
** Invoke deploy:finishing (first_time)
** Execute deploy:finishing
** Invoke deploy:cleanup (first_time)
** Execute deploy:cleanup
** Invoke deploy:finished (first_time)
** Execute deploy:finished
** Invoke deploy:log_revision (first_time)
** Execute deploy:log_revision
00:00 deploy:log_revision
      01 echo "Branch master (at ) deployed as release 20210225063333 by user" >> /var/www/Date_me/revisions.log
```
`before :start, :make_dirs`の記述を消すとエラーが消えることから、この箇所が原因だろうと予測していますが、その先どのように修正すれば良いかがわからず、アドバイスをいただきたいです。