### PR TITLE
AWSでrails consoleを使えるようにgem追加

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -9,6 +9,7 @@ require 'capistrano/yarn'
 require "capistrano/scm/git"
 require "capistrano/puma"
 require "capistrano/nginx"
+require 'capistrano/rails/console'
 
 install_plugin Capistrano::SCM::Git
 install_plugin Capistrano::Puma

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :development do
   gem 'capistrano3-puma', github: "seuros/capistrano-puma"
   gem 'capistrano-nginx'
   gem 'capistrano-yarn'
+  gem 'capistrano-rails-console'
 
 #エラー画面をわかりやすくしてくれる&ブラウザ上でirbを使えるようにする
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,9 @@ GEM
     capistrano-rails (1.6.1)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
+    capistrano-rails-console (2.3.0)
+      capistrano (>= 3.5.0, < 4.0.0)
+      sshkit-interactive (~> 0.3.0)
     capistrano-rbenv (2.2.0)
       capistrano (~> 3.1)
       sshkit (~> 1.3)
@@ -272,6 +275,8 @@ GEM
     sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    sshkit-interactive (0.3.0)
+      sshkit (~> 1.12)
     temple (0.8.2)
     thor (1.1.0)
     tilt (2.0.10)
@@ -309,6 +314,7 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-nginx
   capistrano-rails
+  capistrano-rails-console
   capistrano-rbenv
   capistrano-yarn
   capistrano3-puma!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,6 @@ Rails.application.routes.draw do
   resources :schedules, only: [:create, :new, :update, :index, :destroy]
   resources :make_plans, only: [:create]
   resources :today_missions, only: [:update]
-  resource :session, only: [:show, :create]
 
   root 'schedules#show'
   get '/missions/:token/:user' => 'missions#index'


### PR DESCRIPTION
## 概要
本番環境でrails consoleを使えるようにするため、'capistrano-rails-console'を導入しました。

## 確認方法
Gem を追加したので `bundle install` を実行してください