### PR TITLE
本番環境でcronに設定した内容が実行されない

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -35,21 +35,6 @@ set :whenever_identifier, ->{ "#{fetch(:application)}_#{fetch(:stage)}" }
 #   before :start, :make_dirs
 # end
 
-desc 'set crontab'
-  task :whenever do
-    on roles(:app) do
-      ### ↓追記ここから
-      within previous_release do
-        execute :bundle, :exec, 'whenever --clear-crontab'
-      end
-      ### ↑追記ここまで
-
-      within release_path do
-        execute :bundle, :exec, 'whenever --update-crontab'
-      end
-    end
-  end
-
 namespace :deploy do
   desc 'upload important files'
   task :upload do

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,7 +4,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
   config.hosts << '.ngrok.io'
   config.hosts.clear
-  config.web_console.whitelisted_ips = '39.110.218.243'
+  # config.web_console.whitelisted_ips = '39.110.218.243'
 
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development


### PR DESCRIPTION
### 質問内容・実現したいこと

cronを実行させたい

### 現状発生している問題・エラーメッセージ

var/www/Date_me/shared/log/cron.log
(EC2)
```
rake aborted!
LoadError: cannot load such file -- io/console/size
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:34:in `require'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/zeitwerk-2.4.2/lib/zeitwerk/kernel.rb:34:in `require'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/actionpack-6.1.2.1/lib/action_dispatch/routing/inspector.rb:4:in `<main>'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/zeitwerk-2.4.2/lib/zeitwerk/kernel.rb:34:in `require'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/actionpack-6.1.2.1/lib/action_dispatch/middleware/debug_exceptions.rb:5:in `<main>'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/zeitwerk-2.4.2/lib/zeitwerk/kernel.rb:34:in `require'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/railties-6.1.2.1/lib/rails/application/default_middleware_stack.rb:52:in `block in build_stack'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/actionpack-6.1.2.1/lib/action_dispatch/middleware/stack.rb:72:in `initialize'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/railties-6.1.2.1/lib/rails/application/default_middleware_stack.rb:15:in `new'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/railties-6.1.2.1/lib/rails/application/default_middleware_stack.rb:15:in `build_stack'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/railties-6.1.2.1/lib/rails/application.rb:587:in `default_middleware_stack'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/railties-6.1.2.1/lib/rails/engine.rb:523:in `block in app'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/railties-6.1.2.1/lib/rails/engine.rb:521:in `synchronize'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/railties-6.1.2.1/lib/rails/engine.rb:521:in `app'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/railties-6.1.2.1/lib/rails/application/finisher.rb:108:in `block in <module:Finisher>'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/railties-6.1.2.1/lib/rails/initializable.rb:32:in `instance_exec'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/railties-6.1.2.1/lib/rails/initializable.rb:32:in `run'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/railties-6.1.2.1/lib/rails/initializable.rb:61:in `block in run_initializers'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/railties-6.1.2.1/lib/rails/initializable.rb:60:in `run_initializers'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/railties-6.1.2.1/lib/rails/application.rb:384:in `initialize!'
/var/www/Date_me/releases/20210306065820/config/environment.rb:5:in `<main>'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/zeitwerk-2.4.2/lib/zeitwerk/kernel.rb:34:in `require'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/activesupport-6.1.2.1/lib/active_support/dependencies.rb:332:in `block in require'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/activesupport-6.1.2.1/lib/active_support/dependencies.rb:299:in `load_dependency'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/activesupport-6.1.2.1/lib/active_support/dependencies.rb:332:in `require'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/railties-6.1.2.1/lib/rails/application.rb:360:in `require_environment!'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/railties-6.1.2.1/lib/rails/application.rb:526:in `block in run_tasks_blocks'
/var/www/Date_me/shared/bundle/ruby/2.6.0/gems/rake-13.0.3/exe/rake:27:in `<top (required)>'
/home/aina/.gem/ruby/gems/bundler-2.2.11/lib/bundler/cli/exec.rb:63:in `load'
/home/aina/.gem/ruby/gems/bundler-2.2.11/lib/bundler/cli/exec.rb:63:in `kernel_load'
/home/aina/.gem/ruby/gems/bundler-2.2.11/lib/bundler/cli/exec.rb:28:in `run'
/home/aina/.gem/ruby/gems/bundler-2.2.11/lib/bundler/cli.rb:494:in `exec'
/home/aina/.gem/ruby/gems/bundler-2.2.11/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/home/aina/.gem/ruby/gems/bundler-2.2.11/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/home/aina/.gem/ruby/gems/bundler-2.2.11/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/home/aina/.gem/ruby/gems/bundler-2.2.11/lib/bundler/cli.rb:30:in `dispatch'
/home/aina/.gem/ruby/gems/bundler-2.2.11/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/home/aina/.gem/ruby/gems/bundler-2.2.11/lib/bundler/cli.rb:24:in `start'
/home/aina/.gem/ruby/gems/bundler-2.2.11/exe/bundle:49:in `block in <top (required)>'
/home/aina/.gem/ruby/gems/bundler-2.2.11/lib/bundler/friendly_errors.rb:130:in `with_friendly_errors'
/home/aina/.gem/ruby/gems/bundler-2.2.11/exe/bundle:37:in `<top (required)>'
/home/aina/bin/bundle:23:in `load'
/home/aina/bin/bundle:23:in `<main>'
Tasks: TOP => push:push_mission => environment
(See full trace by running task with --trace)
```

### 該当のソースコード

config/deploy.rb
```
# config valid for current version and patch releases of Capistrano
lock "~> 3.15.0"

set :nginx_downstream_uses_ssl, true
set :application, "Date_me"
set :repo_url, "git@github.com:terakura-aina/Date_me.git" # 自身のリモートリポジトリURL
set :user, 'aina'
set :deploy_to, "/var/www/Date_me"
set :linked_files, %w[config/master.key config/database.yml .env]
set :linked_dirs, %w[log tmp/pids tmp/cache tmp/sockets public/system vendor/bundle]
set :rbenv_ruby, File.read('.ruby-version').strip
set :puma_threds, [4, 16]
set :puma_workers, 0
set :puma_bind, "unix:///var/www/Date_me/shared/tmp/sockets/puma.sock"
set :puma_state, "/var/www/Date_me/shared/tmp/pids/puma.state"
set :puma_pid, "/var/www/Date_me/shared/tmp/pids/puma.pid"
set :puma_access_log, "/var/www/Date_me/shared/log/puma.error.log"
set :puma_error_log, "/var/www/Date_me/shared/log/puma.access.log"
set :puma_preload_app, true
set :branch, ENV['BRANCH'] || "main"
set :puma_systemctl_bin, '/usr/bin/systemctl'
set :puma_systemctl_user, :system
set :whenever_identifier, ->{ "#{fetch(:application)}_#{fetch(:stage)}" }


# namespace :puma do
#   desc 'Create Directories for Puma Pids and Socket'
#   task :make_dirs do
#     on roles(:app) do
#       execute "mkdir /var/www/Date_me/shared/tmp/sockets -p"
#       execute "mkdir /var/www/Date_me/shared/tmp/pids -p"
#     end
#   end

#   before :start, :make_dirs
# end

namespace :deploy do
  desc 'upload important files'
  task :upload do
    on roles(:app) do
      sudo :mkdir, '-p', "/var/www/Date_me/shared/config"
      sudo %[chown -R #{fetch(:user)}.#{fetch(:user)} /var/www/#{fetch(:application)}]
      sudo :mkdir, '-p', '/etc/nginx/sites-enabled'
      sudo :mkdir, '-p', '/etc/nginx/sites-available'

      upload!('.env.production', "/var/www/Date_me/shared/.env")
      upload!('config/database.yml', "/var/www/Date_me/shared/config/database.yml")
      upload!('config/master.key', "/var/www/Date_me/shared/config/master.key")
    end
  end

  desc 'Create database'
  task :db_create do
    on roles(:db) do
      with rails_env: fetch(:rails_env) do
        within release_path do
          execute :bundle, :exec, :rake, 'db:create'
        end
      end
    end
  end

  before :starting, :upload
  before 'check:linked_files', 'puma:nginx_config'
end

after 'deploy:published', 'nginx:restart'
before 'deploy:migrate', 'deploy:db_create'

```

Capfile
```
require "capistrano/setup"
require "capistrano/deploy"
require "capistrano/rails"
require "capistrano/rbenv"
require "capistrano/bundler"
require "capistrano/rails/migrations"
require "capistrano/rails/assets"
require 'capistrano/yarn'
require "capistrano/scm/git"
require "capistrano/puma"
require "capistrano/nginx"
require 'capistrano/rails/console'
require 'whenever/capistrano'

install_plugin Capistrano::SCM::Git
install_plugin Capistrano::Puma
install_plugin Capistrano::Puma::Systemd
# install_plugin Capistrano::Puma::Daemon
install_plugin Capistrano::Puma::Nginx

Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }
```

### 試したこと

https://github.com/javan/whenever
公式ページにcapistranoバージョン3のやり方がのっていたので、それを参考にし、以下を追加しました。

Capfile
```
require "whenever/capistrano"
```

config/deploy.rb
```
set :whenever_identifier, ->{ "#{fetch(:application)}_#{fetch(:stage)}" }
```

その後でgit push、bundle exec cap production deployを行いました。
デプロイした際のログを確認したところ、`bundle exec whenever --update-crontab `が実行されているのは確認しています。
```
00:44 whenever:update_crontab
      01 $HOME/.rbenv/bin/rbenv exec bundle exec whenever --update-crontab Date_me_production --set environment=production --roles=app,web,db 
      01 [write] crontab file updated
    ✔ 01 aina@3.113.116.91 1.805s
```

`crontab -l`でcronにセットされているかを確認したところ、productionでセットされているのも確認できました。
```

# Begin Whenever generated tasks for: Date_me at: 2021-03-05 23:30:17 +0900
0,15,30,45 * * * * /bin/bash -l -c 'export PATH="$HOME/.rbenv/bin:$PATH"; eval "$(rbenv init -)"; cd /var/www/Date_me/releases/20210305142938 && RAILS_ENV=production bundle exec rake push:push_remind >> /deploy/apps/Date_me/shared/log/crontab.log 2>&1'

0,5,10,15,20,25,30,35,40,45,50,55 * * * * /bin/bash -l -c 'export PATH="$HOME/.rbenv/bin:$PATH"; eval "$(rbenv init -)"; cd /var/www/Date_me/releases/20210305142938 && RAILS_ENV=production bundle exec rake push:push_mission >> /deploy/apps/Date_me/shared/log/crontab.log 2>&1'

# End Whenever generated tasks for: Date_me at: 2021-03-05 23:30:17 +0900

# Begin Whenever generated tasks for: Date_me_production at: 2021-03-06 16:22:35 +0900
0,15,30,45 * * * * /bin/bash -l -c 'export PATH="$HOME/.rbenv/bin:$PATH"; eval "$(rbenv init -)"; cd /var/www/Date_me/releases/20210306072158 && RAILS_ENV=production bundle exec rake push:push_remind >> /deploy/apps/Date_me/shared/log/crontab.log 2>&1'

0,5,10,15,20,25,30,35,40,45,50,55 * * * * /bin/bash -l -c 'export PATH="$HOME/.rbenv/bin:$PATH"; eval "$(rbenv init -)"; cd /var/www/Date_me/releases/20210306072158 && RAILS_ENV=production bundle exec rake push:push_mission >> /deploy/apps/Date_me/shared/log/crontab.log 2>&1'

# End Whenever generated tasks for: Date_me_production at: 2021-03-06 16:22:35 +0900
```

それでもcronの処理が実行されなかったため、EC2でログが吐き出されているファイルを探し、ログを確認しました。
(恐らくこれだろう、という予想で見つけたログファイルなので間違っていたらすみません)

var/www/Date_me/shared/log/cron.log
```
LoadError: cannot load such file -- io/console/size
```
見たことのないエラーだったので調べたところ、
```
$ sudo yum install ruby-devel
$ gem install io-console
```
これらを実行するとエラーが解消できるといった記事をいくつか見かけたので、実行してみましたが挙動は特に変わりませんでした。
実行した後に、記事にあったエラーはどれも`LoadError: cannot load such file -- io/console`と書かれており、`/size`が入っていなかったことに気がつきました。

そこで改めて`LoadError: cannot load such file -- io/console/size`の解決方法を探してみましたが、見つけられず、どのように対処したら良いかがわかりません。